### PR TITLE
add missing .so file

### DIFF
--- a/debian/libmdcpp.install
+++ b/debian/libmdcpp.install
@@ -1,1 +1,2 @@
 usr/lib/lib*.so.*
+usr/lib/lib*.so


### PR DESCRIPTION
No need to manually `ln -s /usr/lib/libmdcpp.so.1.0 /usr/lib/libmdcpp.so` in https://github.com/sadhen/marketo/wiki/Install-Guide#ubuntu
